### PR TITLE
Add attributes to tags feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ The constructor takes a configuration object with the following properties.
 | `externals` | array&lt;object&gt; | An array of vendor modules that will be excluded from your Webpack bundle and added as `script` or `link` tags in your HTML output. | *None* |
 | `externals[].module` | string | The name of the vendor module. This should match the package name, e.g. if you are writing `import React from 'react'`, this would be `react`. | *None* |
 | `externals[].entry` | string \| array&lt;string&gt; \| object \| array&lt;object \| string&gt; | The path, relative to the vendor module directory, to its pre-bundled distro file. e.g. for React, use `dist/react.js`, since the file exists at `node_modules/react/dist/react.js`. Specify an array if there are multiple CSS/JS files to inject. To use a CDN instead, simply use a fully qualified URL beginning with `http://`, `https://`, or `//`.<br><br>For entries whose type (JS or CSS) cannot be inferred by file extension, pass an object such as `{ path: 'https://some/url', type: 'css' }` (or `type: 'js'`). | *None* |
+| `externals[].entry.path` | string | If entry is an object, the path to the asset. | *None* |
+| `externals[].entry.type` | `'js'`\|`'css'` | The asset type, if it cannot be inferred. | *Inferred by extension when possible* |
+| `externals[].entry.attributes` | object.&lt;string,string&gt; | Additional attributes to add to the injected tag. | `{}` |
 | `externals[].global` | string \| null | For JavaScript modules, this is the name of the object globally exported by the vendor's dist file. e.g. for React, use `React`, since `react.js` creates a `window.React` global. For modules without an export (such as CSS), omit this property or use `null`. | `null` |
 | `externals[].supplements` | array&lt;string&gt; | For modules that require additional resources, specify globs of files to copy over to the output. e.g. for Bootstrap CSS, use `['dist/fonts/']`, since Glyphicon fonts are referenced in the CSS and exist at `node_modules/bootstrap/dist/fonts/`. | `[]` |
 | `externals[].append` | boolean | Set to true to inject this module after your Webpack bundles. | `false` |
@@ -263,6 +266,33 @@ new HtmlWebpackExternalsPlugin({
     },
   ],
   publicPath: '/assets/',
+})
+```
+
+### Adding custom attributes to tags example
+
+Sometimes you may want to add custom attributes to the link or script tags that are injected.
+
+This example does not require the `jquery` module to be installed. It:
+
+1. adds `jquery` to your Webpack config's `externals` object to exclude it from your bundle, telling it to expect a global object called `jQuery` (on the `window` object)
+1. adds `<script type="text/javascript" src="https://code.jquery.com/jquery-3.2.1.js" integrity="sha256-DZAnKJ/6XZ9si04Hgrsxu/8s717jcIzLy3oi35EouyE=" crossorigin="anonymous"></script>` to your HTML file, before your chunks
+
+```js
+new HtmlWebpackExternalsPlugin({
+  externals: [
+    {
+      module: 'jquery',
+      entry: {
+        path: 'https://code.jquery.com/jquery-3.2.1.js',
+        attributes: {
+          integrity: 'sha256-DZAnKJ/6XZ9si04Hgrsxu/8s717jcIzLy3oi35EouyE=',
+          crossorigin: 'anonymous',
+        },
+      },
+      global: 'jQuery',
+    },
+  ],
 })
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1463,9 +1463,9 @@
       }
     },
     "create-github-release": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/create-github-release/-/create-github-release-1.3.0.tgz",
-      "integrity": "sha512-X6MsW+1WSHAREWnWRNRldu+AHUjbRoGg0WOiG5tyqbJGkwV/FuwITsb1F+jYaxgOgAiQrAsIYXROLajq+tu0/w==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/create-github-release/-/create-github-release-1.4.1.tgz",
+      "integrity": "sha512-o1qIgOr/f9ipd3fiajYMznKAygSwg0EifhULYllQiBrBQpBiCxKE10MYqy7AtQm17FE2sm1c8fOVv4tHcPkiPg==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
@@ -1473,6 +1473,7 @@
         "es6-promisify": "5.0.0",
         "github": "11.0.0",
         "lodash.foreach": "4.5.0",
+        "lodash.get": "4.4.2",
         "lodash.isobject": "3.0.2",
         "minimist": "1.2.0",
         "mustache": "2.3.0",
@@ -3171,7 +3172,7 @@
       "requires": {
         "follow-redirects": "0.0.7",
         "https-proxy-agent": "1.0.0",
-        "mime": "1.4.0",
+        "mime": "1.4.1",
         "netrc": "0.1.4"
       }
     },
@@ -4213,6 +4214,12 @@
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -4443,9 +4450,9 @@
       }
     },
     "mime": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.0.tgz",
-      "integrity": "sha512-n9ChLv77+QQEapYz8lV+rIZAW3HhAPW2CXnzb1GN5uMkuczshwvkW7XPsbzU0ZQN3sP47Er2KVkp2p3KyqZKSQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
       "dev": true
     },
     "mimic-fn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3363,9 +3363,9 @@
       }
     },
     "html-webpack-include-assets-plugin": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/html-webpack-include-assets-plugin/-/html-webpack-include-assets-plugin-1.0.0.tgz",
-      "integrity": "sha512-XMSqrRKRa2lo+4PY01tjiptrd2balASnelAsHJYDrxpWGndN+HfrGc+/Y/atWjC248zTGn9lKsSztCGbdjOFIg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/html-webpack-include-assets-plugin/-/html-webpack-include-assets-plugin-1.0.1.tgz",
+      "integrity": "sha512-GOAMbk3TNED1xqQcLbbT0lHelYQd4N5va+kZKEGBSkFLs6jfXK5Xim3yoFgepJUiWAyA5gA1oFjxSXHp95WUlg==",
       "requires": {
         "glob": "7.1.2",
         "minimatch": "3.0.4"

--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
   "dependencies": {
     "ajv": "^5.2.2",
     "copy-webpack-plugin": "^4.0.1",
-    "html-webpack-include-assets-plugin": "^1.0.0"
+    "html-webpack-include-assets-plugin": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "babel-preset-env": "^1.6.0",
     "babel-register": "^6.24.1",
     "bootstrap": "^3.3.7",
-    "create-github-release": "^1.3.0",
+    "create-github-release": "^1.4.1",
     "css-loader": "^0.28.4",
     "escape-string-regexp": "^1.0.5",
     "extract-text-webpack-plugin": "^3.0.0",

--- a/src/HtmlWebpackExternalsPlugin.js
+++ b/src/HtmlWebpackExternalsPlugin.js
@@ -5,7 +5,7 @@ import configSchema from './configSchema.json'
 
 export default class HtmlWebpackExternalsPlugin {
   static validateArguments = (() => {
-    const ajv = new Ajv({ useDefaults: true })
+    const ajv = new Ajv({ useDefaults: true, removeAdditional: true })
     const validateConfig = ajv.compile(configSchema)
 
     return config => {

--- a/src/configSchema.json
+++ b/src/configSchema.json
@@ -20,9 +20,19 @@
                 "type": {
                   "type": "string",
                   "enum": ["js", "css"]
+                },
+                "attributes": {
+                  "type": "object",
+                  "patternProperties": {
+                    "^.+$": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "default": {}
                 }
               },
-              "required": ["path", "type"]
+              "required": ["path"]
             },
             "minItems": 1,
             "properties": {
@@ -32,9 +42,19 @@
               "type": {
                 "type": "string",
                 "enum": ["js", "css"]
+              },
+              "attributes": {
+                "type": "object",
+                "patternProperties": {
+                  "^.+$": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "default": {}
               }
             },
-            "required": ["path", "type"]
+            "required": ["path"]
           },
           "global": {
             "type": ["string", "null"],

--- a/test/HtmlWebpackExternalsPlugin.spec.js
+++ b/test/HtmlWebpackExternalsPlugin.spec.js
@@ -252,6 +252,39 @@ describe('HtmlWebpackExternalsPlugin', function() {
       )
   })
 
+  it('Adding custom attributes to tags example', function() {
+    const integrity = 'sha256-DZAnKJ/6XZ9si04Hgrsxu/8s717jcIzLy3oi35EouyE='
+    const crossorigin = 'anonymous'
+
+    return runWebpack(
+      new HtmlWebpackPlugin(),
+      new HtmlWebpackExternalsPlugin({
+        externals: [
+          {
+            module: 'jquery',
+            entry: {
+              path: 'https://code.jquery.com/jquery-3.2.1.js',
+              attributes: {
+                integrity,
+                crossorigin,
+              },
+            },
+            global: 'jQuery',
+          },
+        ],
+      })
+    )
+      .then(() =>
+        checkHtmlIncludes(
+          'https://code.jquery.com/jquery-3.2.1.js',
+          'js',
+          undefined,
+          undefined,
+          `integrity="${integrity}" crossorigin="${crossorigin}"`
+        )
+      )
+  })
+
   it('Specifying which HTML files to affect example', function() {
     return runWebpack(
       new HtmlWebpackPlugin({

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -62,7 +62,8 @@ export function checkHtmlIncludes(
   file,
   type,
   append = false,
-  htmlFile = 'index.html'
+  htmlFile = 'index.html',
+  additionalContent = null
 ) {
   return promisify(
     fs.readFile,
@@ -71,12 +72,12 @@ export function checkHtmlIncludes(
   ).then(contents => {
     if (type === 'js') {
       assert.ok(
-        contents.match(new RegExp(`<script.*src="${escapeRegExp(file)}".*>`)),
+        contents.match(new RegExp(`<script type="text/javascript" src="${escapeRegExp(file)}".*></script>`)),
         `${file} script was not inserted into the HTML output`
       )
     } else if (type === 'css') {
       assert.ok(
-        contents.match(new RegExp(`<link.*href="${escapeRegExp(file)}".*>`)),
+        contents.match(new RegExp(`<link href="${escapeRegExp(file)}" rel="stylesheet".*>`)),
         `${file} link was not inserted into the HTML output`
       )
     }
@@ -91,6 +92,20 @@ export function checkHtmlIncludes(
         ? 'after'
         : 'before'} the bundle`
     )
+
+    if (additionalContent) {
+      if (type === 'js') {
+        assert.ok(
+          contents.match(new RegExp(`<script type="text/javascript" src="${escapeRegExp(file)}" ${escapeRegExp(additionalContent)}></script>`)),
+          `${file} script did not include attributes ${additionalContent}`
+        )
+      } else if (type === 'css') {
+        assert.ok(
+          contents.match(new RegExp(`<link href="${escapeRegExp(file)}" rel="stylesheet" ${escapeRegExp(additionalContent)}>`)),
+          `${file} link did not include attributes ${additionalContent}`
+        )
+      }
+    }
   })
 }
 


### PR DESCRIPTION
This is contingent on an update to [`html-webpack-include-assets-plugin`](https://github.com/jharris4/html-webpack-include-assets-plugin), of which I have opened a [pull request](https://github.com/jharris4/html-webpack-include-assets-plugin/pull/14) against. If this is released, then CI should go green on this branch as soon as the dependency version is bumped.

This will solve #17 and #18.